### PR TITLE
Replacing Nuxt images with native images

### DIFF
--- a/components/Book.vue
+++ b/components/Book.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="book">
     <div class="book__art">
-      <nuxt-picture
+      <img
         :src="book.image"
         :alt="book.title"
         loading="lazy"

--- a/components/ProjectCard.vue
+++ b/components/ProjectCard.vue
@@ -1,11 +1,7 @@
 <template>
   <article class="project">
     <div class="project__image">
-      <nuxt-picture
-        :src="project.previewImage"
-        :alt="project.title"
-        loading="lazy"
-      />
+      <img :src="project.previewImage" :alt="project.title" loading="lazy" />
     </div>
     <div class="project__content">
       <h3>

--- a/pages/projects/[slug].vue
+++ b/pages/projects/[slug].vue
@@ -9,7 +9,7 @@
       </div>
     </header>
     <article class="section">
-      <nuxt-picture
+      <img
         v-if="project.featuredImage"
         class="featured-image"
         :src="project.featuredImage"
@@ -18,7 +18,7 @@
       <div class="container container--narrow">
         <div class="content">
           <div class="content__image">
-            <nuxt-picture
+            <img
               v-if="!project.featuredImage"
               :src="project.previewImage"
               :alt="project.title"


### PR DESCRIPTION
Apparently, the Nuxt Image module doesn't work with Nuxt 3 yet? I'm temporarily replacing all of images with the native `img` tag but will look into this later.